### PR TITLE
Add country to list of known attributes

### DIFF
--- a/lib/samurai/payment_method.rb
+++ b/lib/samurai/payment_method.rb
@@ -50,7 +50,7 @@ class Samurai::PaymentMethod < Samurai::Base
 
   # Setup the PaymentMethod schema for ActiveResource, so that new objects contain empty attributes
   KNOWN_ATTRIBUTES = [
-    :first_name, :last_name, :address_1, :address_2, :city, :state, :zip,
+    :first_name, :last_name, :address_1, :address_2, :city, :state, :zip, :country, 
     :card_number, :cvv, :expiry_month, :expiry_year, :sandbox, :custom
   ]
   include Samurai::ActiveResourceSupport

--- a/spec/lib/payment_method_spec.rb
+++ b/spec/lib/payment_method_spec.rb
@@ -113,6 +113,7 @@ describe "PaymentMethod" do
         :address_2    => "Apt #3X",
         :city         => "ChicagoX",
         :state        => "IL",
+        :country      => "US",
         :zip          => "10101",
         :card_number  => "5454-5454-5454-5454",
         :cvv          => "456",
@@ -133,6 +134,7 @@ describe "PaymentMethod" do
         pm.city.should        == @params[:city]
         pm.state.should       == @params[:state]
         pm.zip.should         == @params[:zip]
+        pm.country.should     == @params[:country]
         pm.last_four_digits.should == @params[:card_number][-4, 4]
         pm.expiry_month.should  == @params[:expiry_month].to_i
         pm.expiry_year.should   == @params[:expiry_year].to_i
@@ -154,6 +156,7 @@ describe "PaymentMethod" do
         pm.city.should        == @params[:city]
         pm.state.should       == @params[:state]
         pm.zip.should         == @params[:zip]
+        pm.country.should     == @params[:country]
         pm.last_four_digits.should == '1111'
         pm.expiry_month.should  == @params[:expiry_month].to_i
         pm.expiry_year.should   == @params[:expiry_year].to_i
@@ -233,6 +236,7 @@ describe "PaymentMethod" do
         pm.city.should        == @params[:city]
         pm.state.should       == @params[:state]
         pm.zip.should         == @params[:zip]
+        pm.country.should     == @params[:country]
         pm.last_four_digits.should == @params[:card_number][-4, 4]
         pm.expiry_month.should  == @params[:expiry_month].to_i
         pm.expiry_year.should   == @params[:expiry_year].to_i
@@ -263,6 +267,7 @@ describe "PaymentMethod" do
         pm.city.should        == @params[:city]
         pm.state.should       == @params[:state]
         pm.zip.should         == @params[:zip]
+        pm.country.should     == @params[:country]
         pm.last_four_digits.should == @params[:card_number][-4, 4]
         pm.expiry_month.should  == @params[:expiry_month].to_i
         pm.expiry_year.should   == @params[:expiry_year].to_i
@@ -294,6 +299,7 @@ describe "PaymentMethod" do
         pm.city.should        == @params[:city]
         pm.state.should       == @params[:state]
         pm.zip.should         == @params[:zip]
+        pm.country.should     == @params[:country]
         pm.last_four_digits.should == @params[:card_number][-4, 4]
         pm.expiry_month.should  == @params[:expiry_month].to_i
         pm.expiry_year.should   == @params[:expiry_year].to_i

--- a/spec/support/transparent_redirect_helper.rb
+++ b/spec/support/transparent_redirect_helper.rb
@@ -40,6 +40,7 @@ module TransparentRedirectHelper
       'credit_card[city]' => 'Chicago',
       'credit_card[state]' => 'IL',
       'credit_card[zip]' => '10101',
+      'credit_card[country]' => 'US',
       'credit_card[card_number]' => '4111111111111111',
       'credit_card[cvv]' => '111',
       'credit_card[expiry_month]' => '05',


### PR DESCRIPTION
Otherwise, it's only available AFTER the `PaymentMethod` is returned from Samurai and you'll get a `NoMethodError` when trying to reference it.  I encountered this when customizing my own payment form.
